### PR TITLE
Add npm `main` file entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "Jurgen Van de Moere",
     "email": "jurgen.van.de.moere@gmail.com"
   },
-  "main": "dist/angular-contentful",
+  "main": "dist/angular-contentful.js",
   "scripts": {
     "test": "gulp test-dist-minified"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "name": "Jurgen Van de Moere",
     "email": "jurgen.van.de.moere@gmail.com"
   },
+  "main": "dist/angular-contentful",
   "scripts": {
     "test": "gulp test-dist-minified"
   },


### PR DESCRIPTION
Added `main` entry to `package.json`, see https://docs.npmjs.com/files/package.json#main

---

Without a `main` entry, to use it you need to write:

```
import 'angular-contentful/dist/angular-contentful';
```

With a `main` entry, you can just write:

```
import 'angular-contentful';
```
