### PR TITLE
Build the URL with environment if present

### DIFF
--- a/src/contentful/services/contentful.service.js
+++ b/src/contentful/services/contentful.service.js
@@ -96,6 +96,8 @@
         this.options[optionSet].secure ? '443' : '80',
         '/spaces/',
         this.options[optionSet].space,
+        this.options.environment ? '/environments/': '',
+        this.options.environment ? this.options.environment: '',
         path
       ].join('');
 


### PR DESCRIPTION
By default the requests always go to the **master** environment of the space, you have to include the `environments/${environmentId}`path in the url.

[See here the official documentation](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/links/retrieval-of-linked-items/query-entries/console/curl)